### PR TITLE
fix regression: allow to provide webpack devtool

### DIFF
--- a/webpack/index.js
+++ b/webpack/index.js
@@ -116,6 +116,8 @@ function createVariant(variant) {
           workers({
             config: {
               baseDir: config.baseDir,
+              developmentDevtool: config.developmentDevtool,
+              productionDevtool: config.productionDevtool,
             },
             entries: result.entries,
             pckg: result.pckg,


### PR DESCRIPTION
"devtool" is used in development.js and production.js but never defined. This commit fixes this.
Now you can provide devtools like this:

```
gg({
    "baseDir": __dirname,
    "developmentDevtool": "cheap-module-eval-source-map",
    "productionDevtool": "none"
}).setup(gulp);
```